### PR TITLE
updating to push website configuration data on activate

### DIFF
--- a/lib/s3-adapter.js
+++ b/lib/s3-adapter.js
@@ -119,8 +119,7 @@ module.exports = CoreObject.extend({
     if (currentRevisions.indexOf(revision) > -1) {
       return new Promise(function(resolve, reject) {
         this._getFileContents(revision + '.html')
-        .then(this._getUploadParams.bind(this, 'index'))
-        .then(this._setFileContents.bind(this))
+        .then(this._updateBucketWebsite.bind(this, revision))
         .then(function() {
           resolve();
         })
@@ -291,6 +290,55 @@ module.exports = CoreObject.extend({
         }
       }.bind(this));
     }.bind(this));
+  },
+
+ /**
+  * Updates website index document to point to a new revision.
+  * @param {string} revision - revision to update index to
+  * @returns {RSVP.Promise}
+  */
+  _updateBucketWebsite: function(revision){
+    return new Promise(function(resolve, reject) {
+      var params = this._getWebsiteParams(revision);
+      this.client.putBucketWebsite(params, function(err, data) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data.Body);
+        }
+      });
+    }.bind(this));
+  },
+
+ /**
+  * Generates parameters for bucket website configuration.
+  * @param {string} revision - revision to update index to
+  * @returns {Object}
+  */
+  _getWebsiteParams: function(revision){
+    return {
+      Bucket: this.config. bucket, /* required */
+      WebsiteConfiguration: { /* required */
+        ErrorDocument: {
+          Key: 'error.html' /* required */
+        },
+        IndexDocument: {
+          Suffix: revision +'.html' /* required */
+        },
+
+        RoutingRules: [
+          {
+          Redirect: { /* required */
+            HostName: this.config.hostName,
+            ReplaceKeyPrefixWith: '#/',
+          },
+          Condition: {
+            HttpErrorCodeReturnedEquals: '404',
+          }
+        },
+        ]
+      }
+    };
   },
 
   _getUploadParams: function(key, value) {


### PR DESCRIPTION
Updating to use the website index replacement method, rather than rewriting the index file.
